### PR TITLE
refactor(logger): remove ";" after logging definitions (IMPORTANT)

### DIFF
--- a/src/logger/Logger.h
+++ b/src/logger/Logger.h
@@ -7,16 +7,16 @@
 
 using namespace std;
 
-#define L_DEBUG(message) Logger::getInstance()->log(LogLevel::DEBUG, message);
+#define L_DEBUG(message) Logger::getInstance()->log(LogLevel::DEBUG, message)
 #define L_VERBOSE(message) \
-    Logger::getInstance()->log(LogLevel::VERBOSE, message);
-#define L_INFO(message) Logger::getInstance()->log(LogLevel::INFO, message);
+    Logger::getInstance()->log(LogLevel::VERBOSE, message)
+#define L_INFO(message) Logger::getInstance()->log(LogLevel::INFO, message)
 #define L_SUCCESS(message) \
-    Logger::getInstance()->log(LogLevel::SUCCESS, message);
+    Logger::getInstance()->log(LogLevel::SUCCESS, message)
 #define L_WARNING(message) \
     Logger::getInstance()->log(LogLevel::WARNING, message);
-#define L_ERROR(message) Logger::getInstance()->log(LogLevel::ERROR, message);
-#define L_FATAL(message) Logger::getInstance()->log(LogLevel::FATAL, message);
+#define L_ERROR(message) Logger::getInstance()->log(LogLevel::ERROR, message)
+#define L_FATAL(message) Logger::getInstance()->log(LogLevel::FATAL, message)
 
 enum class LogLevel : short {
     /**

--- a/src/utils/Timer.cpp
+++ b/src/utils/Timer.cpp
@@ -47,13 +47,13 @@ void Timer ::start() {
 
             mutex.lock();
             if (timerState == TICKING) {
-                L_DEBUG("TIMEOUT " + NAME + ": performing actions")
+                L_DEBUG("TIMEOUT " + NAME + ": performing actions");
                 timerState = EXECUTING_SCHEDULED_TASK;
                 stateMachine->enqueueEvent(eventToSendUponExpire);
                 timerState = COMPLETED;
 
             } else {
-                L_DEBUG(NAME + ": " + "was stopped, skipping actions")
+                L_DEBUG(NAME + ": " + "was stopped, skipping actions");
             }
 
             auto end = std::chrono::steady_clock::now();


### PR DESCRIPTION
Now you need to add `;` after the logging methods